### PR TITLE
Add ssh flag to cargo run layer

### DIFF
--- a/rust/Earthfile
+++ b/rust/Earthfile
@@ -56,7 +56,7 @@ CARGO:
     IF [ "$EARTHLY_KEEP_FINGERPRINTS" = "false" ]
        DO +REMOVE_SOURCE_FINGERPRINTS
     END
-    RUN --mount=$EARTHLY_RUST_CARGO_HOME_CACHE --mount=$EARTHLY_RUST_TARGET_CACHE \
+    RUN --ssh --mount=$EARTHLY_RUST_CARGO_HOME_CACHE --mount=$EARTHLY_RUST_TARGET_CACHE \
       set -e; \
       cargo $args; \
       cargo sweep -r -t $EARTHLY_SWEEP_DAYS; \


### PR DESCRIPTION
Modify the `+CARGO` function so that the layer that actually runs the `cargo ...` commands can access the ssh authentication client running on the host via the socket which is referenced by the environment variable `$SSH_AUTH_SOCK`.